### PR TITLE
additional Fixes

### DIFF
--- a/JMMServer/Repositories/GroupFilterRepository.cs
+++ b/JMMServer/Repositories/GroupFilterRepository.cs
@@ -102,7 +102,14 @@ namespace JMMServer.Repositories
 
 		public List<GroupFilter> GetLockedGroupFilters(ISession session)
 		{
-		    return Cache.Values.Where(a => a.Locked == 1).ToList();
+            if (Cache != null)
+            {
+                return Cache.Values.Where(a => a.Locked == 1).ToList();
+            }
+            else
+            {
+                return new List<GroupFilter>();
+            }
 		}
 
 		public void Delete(int id)

--- a/JMMServer/Repositories/VideoLocalRepository.cs
+++ b/JMMServer/Repositories/VideoLocalRepository.cs
@@ -301,7 +301,14 @@ namespace JMMServer.Repositories
 
 		public List<VideoLocal> GetAll()
 		{
-		    return Cache.Values.ToList();
+            if (Cache != null)
+            {
+                return Cache.Values.ToList();
+            }
+            else
+            {
+                return new List<VideoLocal>();
+            }
 		}
 		
 


### PR DESCRIPTION
during updating schemas, JMMS tries to get lists out of the cache,
although it's still null. returning an empty list prevents an abortion
of the operation, and thus allows setting up the db properly
